### PR TITLE
Only execute future once when logging duration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
   "com.google.inject.extensions" % "guice-assistedinject" % "4.2.3",
   "net.codingwell" %% "scala-guice" % "4.2.6",
   "net.logstash.logback" % "logstash-logback-encoder" % "6.3", // structured logging to sumo
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
   // The following will need to be provided by users of this lib,
   // meaning they can supply their own version (as long as compatible).
   "com.typesafe.play" %% "play-json" % "2.8.1" % Provided,

--- a/src/main/scala/io/flow/log/LogUtil.scala
+++ b/src/main/scala/io/flow/log/LogUtil.scala
@@ -64,9 +64,8 @@ class LogUtil @Inject() (logger: RollbarLogger) {
   )(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
     if (frequency == 1L || Random.nextLong() % frequency == 0) {
       val start = System.currentTimeMillis()
-      f.onComplete { _ =>
+      f.andThen { _ =>
         val end = System.currentTimeMillis()
-
         logger
           .fingerprint(fingerprint)
           .organization(organizationId)
@@ -79,7 +78,6 @@ class LogUtil @Inject() (logger: RollbarLogger) {
           .withKeyValue("duration", end - start)
           .info(info)
       }
-      f
     } else
       f
   }

--- a/src/test/scala/io/flow/log/LogUtilSpec.scala
+++ b/src/test/scala/io/flow/log/LogUtilSpec.scala
@@ -1,0 +1,43 @@
+package io.flow.log
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class LogUtilSpec extends AnyWordSpec with Matchers {
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  "LogUtil" when {
+    val logUtil = new LogUtil(RollbarLogger.SimpleLogger)
+
+    "log duration" should {
+      "only execute function once" in {
+        val callCount = new AtomicInteger(0)
+        def f = {
+          callCount.incrementAndGet()
+        }
+        logUtil.duration(info = "test", fingerprint = "test", organizationId = "test")(f)
+        callCount.get must be (1)
+      }
+    }
+
+    "log duration future" should {
+      "only execute future once" in {
+        val callCount = new AtomicInteger(0)
+        def f = Future {
+          callCount.incrementAndGet()
+        }
+        Await.result(
+          logUtil.durationF(info = "test", fingerprint = "test", organizationId = "test")(f),
+          10.millis
+        )
+        callCount.get must be (1)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added tests as previous implementation executed the future function twice.

`durationF` is used in services:
- payment
- metric
- shopify