### PR TITLE
Fix the com.rollbar.notifier.sender.exception.SenderException we've been seeing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val allScalacOptions = Seq(
 
 libraryDependencies ++= Seq(
   "io.flow" %% s"lib-util" % "0.1.88",
-  "com.rollbar" % "rollbar-java" % "1.7.10",
+  "com.rollbar" % "rollbar-java" % "1.8.1",
   "com.google.inject.extensions" % "guice-assistedinject" % "4.2.3",
   "net.codingwell" %% "scala-guice" % "4.2.11",
   "net.logstash.logback" % "logstash-logback-encoder" % "6.3", // structured logging to sumo

--- a/src/main/scala/io/flow/log/Rollbar.scala
+++ b/src/main/scala/io/flow/log/Rollbar.scala
@@ -120,20 +120,23 @@ object RollbarProvider {
         mapper.writeValueAsString(payload)
       }
 
-      case class ResultObj(code: Int = -1, message: Option[String], uuid: Option[String])
-
       override def resultFrom(response: String): Result = {
-        Try {
-          Json.parse(response).validate(Json.reads[ResultObj]).map { obj =>
-            val body = if (obj.code == 0) {
-              obj.uuid.orElse(obj.message).getOrElse(s"No message or uuid in response: $response")
-            } else {
-              obj.message.orElse(obj.uuid).getOrElse(s"No message or uuid in response: $response")
-            }
-            new Result.Builder().code(obj.code).body(body).build
-          }.asOpt
-        }.toOption.flatten.getOrElse {
-          new Result.Builder().code(1).body(s"Invalid response: $response").build()
+        val resultOpt = for {
+          obj <- Json.parse(response).validate[JsObject]
+          err <- (obj \ "err").validate[Int]
+          content <- {
+            if (err == 0)
+              (obj \ "result" \ "uuid").validate[String]
+            else
+              (obj \ "message").validate[String]
+          }
+        } yield new Result.Builder().code(err).body(content).build
+
+        resultOpt match {
+          case JsSuccess(res, _) => res
+          case JsError(errors) => new Result.Builder().code(-1).body(
+            JsError.toJson(errors).toString
+          ).build
         }
       }
     }

--- a/src/main/scala/io/flow/log/Rollbar.scala
+++ b/src/main/scala/io/flow/log/Rollbar.scala
@@ -18,8 +18,6 @@ import net.codingwell.scalaguice.ScalaModule
 import play.api.libs.json._
 import play.api.libs.json.jackson.PlayJsonModule
 
-import scala.util.Try
-
 class RollbarModule extends AbstractModule with ScalaModule {
   override def configure(): Unit = {
     bind[Option[Rollbar]].toProvider[RollbarProvider]


### PR DESCRIPTION
Rollbar changed their response format and we were parsing it ourselves

```
"com.rollbar.notifier.sender.exception.SenderException: com.rollbar.notifier.sender.exception.ApiException: Invalid response: {
  "err": 0,
  "result": {
    "id": null,
    "uuid": "ce1a9eabab774bb79cdf59ee1619e7b4"
  }
}
	at com.rollbar.notifier.sender.AbstractSender.send(AbstractSender.java:39)
	at com.rollbar.notifier.sender.BufferedSender$SendTask.run(BufferedSender.java:277)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:830)
Caused by: com.rollbar.notifier.sender.exception.ApiException: Invalid response: {
  "err": 0,
  "result": {
    "id": null,
    "uuid": "ce1a9eabab774bb79cdf59ee1619e7b4"
  }
}
	... 8 common frames omitted
"
```