### PR TITLE
Take environment from custom payload

### DIFF
--- a/src/main/scala/io/flow/log/Rollbar.scala
+++ b/src/main/scala/io/flow/log/Rollbar.scala
@@ -145,7 +145,7 @@ object RollbarProvider {
         Option(data.getCustom)
           .flatMap(custom => Option(custom.get(RollbarLogger.Keys.Environment)))
           .flatMap(env => Option.when(!env.toString.isBlank)(env.toString))
-          .fold(data) { environment =>
+          .fold(ifEmpty = data) { environment =>
             new Data.Builder(data)
               .environment(environment)
               .build()

--- a/src/main/scala/io/flow/log/RollbarLogger.scala
+++ b/src/main/scala/io/flow/log/RollbarLogger.scala
@@ -3,6 +3,7 @@ package io.flow.log
 import cats.data.NonEmptyChain
 import com.google.inject.assistedinject.{Assisted, AssistedInject}
 import com.rollbar.notifier.Rollbar
+import io.flow.common.v0.models.Environment
 import net.logstash.logback.marker.Markers.appendEntries
 import org.slf4j.LoggerFactory
 import play.api.libs.json.{JsValue, Json, Writes}
@@ -33,6 +34,7 @@ object RollbarLogger {
     val ItemNumber = "item_number"
     val ExperienceKey = "experience_key"
     val SuppressRollbar = "suppress_rollbar"
+    val Environment = "environment"
   }
 
   def convert(attributes: Map[String, JsValue]): java.util.Map[String, Object] =
@@ -69,6 +71,7 @@ case class RollbarLogger @AssistedInject() (
   def requestId(value: String): RollbarLogger = withKeyValue(Keys.RequestId, value)
   def itemNumber(value: String): RollbarLogger = withKeyValue(Keys.ItemNumber, value)
   def experienceKey(value: String): RollbarLogger = withKeyValue(Keys.ExperienceKey, value)
+  def environment(environment: Environment): RollbarLogger = withKeyValue(Keys.Environment, environment.toString)
   /**
     * Use for warnings or errors that:
     * - are very high volume


### PR DESCRIPTION
It could be useful to use `organization.environment`  to drive the rollbar environment. Sandbox orgs have a bad habit of clogging our logs, so it would be useful to have a first class ability to filter those out in Rollbar so we don't get alerted on "functional" sandbox errors. 
https://docs.rollbar.com/docs/environments

This would define an `environment` method to define an environment in the custom payload. When Rollbar tries to log, it will go through a transformer to pull that out and override the base configuration. We would still set the application's environment in the base configuration as a fallback.
https://docs.rollbar.com/docs/java#transforming-the-payload