### PR TITLE
Upgrade to rollbar-java 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val allScalacOptions = Seq(
 
 libraryDependencies ++= Seq(
   "io.flow" %% s"lib-util" % "0.2.50",
-  "com.rollbar" % "rollbar-java" % "1.10.3",
+  "com.rollbar" % "rollbar-java" % "2.0.0-alpha.1",
   "com.google.inject.extensions" % "guice-assistedinject" % "4.2.3",
   "org.typelevel" %% "cats-core" % "2.10.0",
   "net.codingwell" %% "scala-guice" % "4.2.11",


### PR DESCRIPTION
2.0.0-alpha.1 is the same as 2.0.0 (the latter is missing in maven central). See https://github.com/rollbar/rollbar-java/issues/322