### PR TITLE
FDN-3369 Allow use of lib without guice injection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,12 +26,11 @@ lazy val allScalacOptions = Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.google.inject" % "guice" % "6.0.0",
-  "com.google.inject.extensions" % "guice-assistedinject" % "6.0.0",
-  "io.flow" %% s"lib-util" % "0.2.53",
+  "com.google.inject" % "guice" % "6.0.0" % Provided,
+  "com.google.inject.extensions" % "guice-assistedinject" % "6.0.0" % Provided,
+  "io.flow" %% s"lib-util" % "0.2.54",
   "com.rollbar" % "rollbar-java" % "2.0.0",
   "org.typelevel" %% "cats-core" % "2.10.0",
-  "net.codingwell" %% "scala-guice" % "4.2.11",
   "net.logstash.logback" % "logstash-logback-encoder" % "6.3", // structured logging to sumo
   "org.scalatest" %% "scalatest" % "3.2.18" % Test,
   "com.typesafe.play" %% "play-json" % "2.10.6",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,7 @@
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 resolvers += "Flow Plugins" at "https://flow.jfrog.io/flow/plugins-release/"
 
-addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.60")
-
-// Resolve scala-xml version dependency mismatch, see https://github.com/sbt/sbt/issues/7007
-ThisBuild / libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)
-
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
-
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
+addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.60")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")

--- a/src/main/scala/io/flow/log/Rollbar.scala
+++ b/src/main/scala/io/flow/log/Rollbar.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializerProvider}
 import com.google.inject.assistedinject.{AssistedInject, FactoryModuleBuilder}
-import com.google.inject.{AbstractModule, Provider}
+import com.google.inject.{AbstractModule, Provider, TypeLiteral}
 import com.rollbar.api.payload.Payload
 import com.rollbar.api.payload.data.Data
 import com.rollbar.notifier.Rollbar
@@ -12,17 +12,16 @@ import com.rollbar.notifier.config.ConfigBuilder
 import com.rollbar.notifier.fingerprint.FingerprintGenerator
 import com.rollbar.notifier.sender.result.Result
 import io.flow.util.{Config, FlowEnvironment}
-import net.codingwell.scalaguice.ScalaModule
 import play.api.libs.json._
 import play.api.libs.json.jackson.PlayJsonMapperModule
 
 import javax.inject.{Inject, Singleton}
 
-class RollbarModule extends AbstractModule with ScalaModule {
+class RollbarModule extends AbstractModule {
   override def configure(): Unit = {
-    bind[Option[Rollbar]].toProvider[RollbarProvider]
+    bind(new TypeLiteral[Option[Rollbar]]() {}).toProvider(classOf[RollbarProvider])
     install(new FactoryModuleBuilder().build(classOf[RollbarLogger.Factory]))
-    bind[RollbarLogger].toProvider[RollbarLoggerProvider]
+    bind(classOf[RollbarLogger]).toProvider(classOf[RollbarLoggerProvider])
     ()
   }
 }

--- a/src/test/scala/io/flow/log/RollbarModuleSpec.scala
+++ b/src/test/scala/io/flow/log/RollbarModuleSpec.scala
@@ -2,16 +2,14 @@ package io.flow.log
 
 import com.google.inject.{AbstractModule, Guice}
 import io.flow.util.Config
-import org.scalatest.wordspec.AnyWordSpec
-import net.codingwell.scalaguice.InjectorExtensions._
-import net.codingwell.scalaguice.ScalaModule
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class RollbarModuleSpec extends AnyWordSpec with Matchers {
 
-  private class MockConfigModule extends AbstractModule with ScalaModule {
+  private class MockConfigModule extends AbstractModule {
     override def configure(): Unit =
-      bind[Config].toInstance(new Config {
+      bind(classOf[Config]).toInstance(new Config {
         override protected def get(name: String): Option[String] = None
         override def optionalList(name: String): Option[Seq[String]] = None
         override def optionalMap(name: String): Option[Map[String, Seq[String]]] = None
@@ -21,7 +19,7 @@ class RollbarModuleSpec extends AnyWordSpec with Matchers {
   "RollbarModule" should {
     "inject rollbar" in {
       val inj = Guice.createInjector(new RollbarModule, new MockConfigModule)
-      noException should be thrownBy inj.instance[RollbarLogger]
+      noException should be thrownBy inj.getInstance(classOf[RollbarLogger])
     }
   }
 


### PR DESCRIPTION
In a lambda for example, one may not use Guice but choose to use `RollbarLogger.SimpleLogger`.
This change allows use of the library without Guice or pulling in the scala guice lib.